### PR TITLE
docs: document PRISM driver read exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ Learn more:
 - [PRISM VDR specification][PRISM-VDR]
 - [Generic VDR specification][Generic-VDR]
 
+### Read / update / delete errors
+
+`read`, `update`, and `delete` signal failures with exceptions (documented in the
+[generic VDR `Driver` contract](https://github.com/hyperledger-identus/vdr/blob/main/src/main/kotlin/org/hyperledger/identus/vdr/interfaces/DriverExceptions.kt)):
+
+| Exception | Meaning |
+| --- | --- |
+| `DataCouldNotBeFoundException` | Missing path identifier or unknown entry |
+| `DataNotInitializedException` | Entry exists on-chain but has no payload yet |
+| `DataAlreadyDeactivatedException` | Entry was deactivated |
+| `DataOfUnexpectedTypeException` | Payload type unsupported for this operation |
+
+`PRISMReadOnlyDriver.read` throws `DataNotInitializedException` or `DataAlreadyDeactivatedException`
+instead of returning an empty byte array, so HTTP layers can return distinct status codes.
+See [hyperledger-identus/vdr#23](https://github.com/hyperledger-identus/vdr/issues/23) and
+[hyperledger-identus/prism-vdr-driver#41](https://github.com/hyperledger-identus/prism-vdr-driver/issues/41).
+
 ## Versions
 
 All published JVM versions are available in [Maven Central - Sonatype](https://central.sonatype.com/artifact/org.hyperledger.identus/prism-vdr-driver_3/versions).

--- a/src/main/scala/hyperledger/identus/vdr/prism/Errors.scala
+++ b/src/main/scala/hyperledger/identus/vdr/prism/Errors.scala
@@ -2,18 +2,24 @@ package hyperledger.identus.vdr.prism
 
 import fmgp.did.method.prism.RefVDR
 
+/** Thrown when the path is invalid or the VDR entry identifier cannot be resolved. */
 class DataCouldNotBeFoundException(reason: Option[String])
     extends Exception(
-      "Could not find the data" + reason.map(s => s" becuase: $s").getOrElse("")
+      "Could not find the data" + reason.map(s => s" because: $s").getOrElse("")
     )
+
+/** Passive drivers do not support create, update, or delete operations. */
 object UnsupportedNotPassiveMethodException
     extends RuntimeException("Passive driver does not support create/update/deactivate events")
 
+/** Thrown by [[PRISMReadOnlyDriver.read]] when the on-chain entry has no payload yet (`DataEmpty`). */
 case class DataNotInitializedException(ref: RefVDR)
     extends RuntimeException(s"'${ref.hex}' VDR entry was not initialized")
 
+/** Thrown by [[PRISMReadOnlyDriver.read]] when the entry was deactivated. */
 case class DataAlreadyDeactivatedException(ref: RefVDR)
     extends RuntimeException(s"'${ref.hex}' VDR entry is already deactivated")
 
+/** Thrown when the entry type is not supported for the requested operation. */
 case class DataOfUnexpectedTypeException(ref: RefVDR)
     extends RuntimeException(s"'${ref.hex}' VDR entry is of an unsupported type for this driver")


### PR DESCRIPTION
## Summary

- Document PRISM driver exception types in `Errors.scala` and README
- Fix typo in `DataCouldNotBeFoundException` message (`becuase` → `because`)

The differentiated `read()` behavior (`DataNotInitializedException` vs `DataAlreadyDeactivatedException`) is already on `main`; this PR documents it for integrators.

Relates to #41.
Relates to hyperledger-identus/vdr#23.

Part of hyperledger-identus/hyperledger-identus#161.

## Test plan

- [x] Documentation-only change (plus one error message typo fix)
- [x] Maintainer review